### PR TITLE
upgrade grype version to v0.32.0

### DIFF
--- a/src/commands/scan-image.yml
+++ b/src/commands/scan-image.yml
@@ -39,7 +39,7 @@ parameters:
     description: enable verbose logs
   grype-version:
     type: string
-    default: v0.26.1
+    default: $GRYPE_VERSION
     description: version of grype used by this orb.
 
 steps:

--- a/src/commands/scan-path.yml
+++ b/src/commands/scan-path.yml
@@ -23,7 +23,7 @@ parameters:
     description: Enable verbose logs
   grype-version:
     type: string
-    default: v0.26.1
+    default: $GRYPE_VERSION
     description: Version of grype used in execution.
 
 steps:

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,4 +1,8 @@
 description: >
   Simple executor
+
+environment:
+  GRYPE_VERSION: v0.32.0
+
 docker:
   - image: cimg/base:stable

--- a/src/jobs/list-dir-vulns.yml
+++ b/src/jobs/list-dir-vulns.yml
@@ -24,7 +24,7 @@ parameters:
     description: enable verbose logs
   grype-version:
     type: string
-    default: v0.26.1
+    default: $GRYPE_VERSION
     description: version of grype used by this orb.
 
 steps:

--- a/src/jobs/list-image-vulns.yml
+++ b/src/jobs/list-image-vulns.yml
@@ -24,7 +24,7 @@ parameters:
     description: enable verbose logs
   grype-version:
     type: string
-    default: v0.26.1
+    default: $GRYPE_VERSION
     description: version of grype used by this orb.
   registry-address:
     type: string


### PR DESCRIPTION
make environment variable to pass version from executor to commands and
jobs. So the version info is saved in only one place, but shared across
the whole orb.

Signed-off-by: Jonas Galvão Xavier <jonas.agx@gmail.com>